### PR TITLE
Making ESM text color visible for dark mode

### DIFF
--- a/AWAREFramework/Classes/ESM/ESMScrollViewCells/BaseESMView.m
+++ b/AWAREFramework/Classes/ESM/ESMScrollViewCells/BaseESMView.m
@@ -108,7 +108,7 @@ NSString * const AWARE_ESM_SELECTION_UPDATE_EVENT_DATA = @"DATA";
         _instructionLabel.text = _esmEntity.esm_instructions;
         _instructionLabel.adjustsFontSizeToFitWidth = YES;
         _instructionLabel.font = [_titleLabel.font fontWithSize:18];
-        [_instructionLabel setTextColor:[UIColor darkTextColor]];
+        [_instructionLabel setTextColor:[UIColor systemGrayColor]];
         _instructionLabel.numberOfLines = 5;
         [self addSubview:_instructionLabel];
         [self extendHeightOfBaseView:HEIGHT_INSTRUCTION];

--- a/AWAREFramework/Classes/ESM/ESMScrollViewController.m
+++ b/AWAREFramework/Classes/ESM/ESMScrollViewController.m
@@ -88,8 +88,7 @@
 - (void)loadView
 {
     [super loadView];
-    UIColor *customColor = [UIColor colorWithRed:0.99 green:0.99 blue:0.99 alpha:1.0];
-    self.view.backgroundColor = customColor;
+
 }
 
 - (void)viewDidLoad {


### PR DESCRIPTION
I noticed that some ESM texts in dark mode are rendered the same as the background color. I'm attempting to fix it with these changes. 